### PR TITLE
Remove TEST_INITIALIZE_MEMORY_DEBUG as they are useless

### DIFF
--- a/tests/uhttp_ut/uhttp_ut.c
+++ b/tests/uhttp_ut/uhttp_ut.c
@@ -425,7 +425,6 @@ static void on_umock_c_error(UMOCK_C_ERROR_CODE error_code)
 }
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 BEGIN_TEST_SUITE(uhttp_ut)
 
@@ -433,7 +432,6 @@ TEST_SUITE_INITIALIZE(suite_init)
 {
     int result;
 
-    TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
     g_testByTest = TEST_MUTEX_CREATE();
     ASSERT_IS_NOT_NULL(g_testByTest);
 
@@ -534,7 +532,6 @@ TEST_SUITE_CLEANUP(suite_cleanup)
     umock_c_deinit();
 
     TEST_MUTEX_DESTROY(g_testByTest);
-    TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
 }
 
 TEST_FUNCTION_INITIALIZE(method_init)


### PR DESCRIPTION
Remove TEST_INITIALIZE_MEMORY_DEBUG as they are useless