### PR TITLE
Fix uhttp dep to allow using c-utility previously included

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(${no_logging})
 endif()
 
 # Include the common build rules for the C SDK
-include("deps/c-utility/configs/azure_iot_build_rules.cmake")
+include("${SHARED_UTIL_FOLDER}/configs/azure_iot_build_rules.cmake")
 
 if(${use_openssl})
     add_definitions(-DUSE_OPENSSL)

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -4,5 +4,7 @@
 if(${use_installed_dependencies})
     find_package(azure_c_shared_utility REQUIRED CONFIG)
 else()
-    add_subdirectory(deps/c-utility EXCLUDE_FROM_ALL)
+    if("${SHARED_UTIL_FOLDER}" STREQUAL "")
+        add_subdirectory(deps/c-utility EXCLUDE_FROM_ALL)
+    endif()
 endif()


### PR DESCRIPTION
This will allow other projects to include uhttp in a flat dependency structure along with c-utility