### PR TITLE
Fixing uhttp memory leak and unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,6 +199,9 @@ common/tools/macro_utils_h_generator/macro_utils_h_generator.exe
 **/.vscode/**
 # C/C++ extension for VS Code
 .browse.VC.db*
+GPATH
+GRTAGS
+GTAGS
 
 build_all/windows/nuget.exe
 

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -1128,6 +1128,7 @@ HTTP_CLIENT_RESULT uhttp_client_open(HTTP_CLIENT_HANDLE handle, const char* host
                         http_data->on_connect = NULL;
                         http_data->connect_user_ctx = NULL;
                         http_data->port_num = 0;
+                        http_data->recv_msg.recv_state = state_error;
 
                         result = HTTP_CLIENT_OPEN_FAILED;
                     }

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -28,11 +28,10 @@
 
 static const char* HTTP_REQUEST_LINE_FMT = "%s %s HTTP/1.1\r\n";
 static const char* HTTP_HOST = "Host";
+// The following header names MUST be lowercase as they are used for HTTP response header comparison:
 static const char* HTTP_CONTENT_LEN = "content-length";
 static const char* HTTP_TRANSFER_ENCODING = "transfer-encoding";
-//static const char* HTTP_CHUNKED_ENCODING_HDR = "Transfer-Encoding: chunked\r\n";
 static const char* HTTP_CRLF_VALUE = "\r\n";
-//static const char* FORMAT_HEX_CHAR = "0x%02x ";
 
 typedef enum RESPONSE_MESSAGE_STATE_TAG
 {
@@ -862,7 +861,7 @@ static int construct_http_headers(HTTP_HEADERS_HANDLE http_header, size_t conten
         if (result == 0)
         {
             /* Codes_SRS_UHTTP_07_015: [uhttp_client_execute_request shall add the Content-Length to the request if the contentLength is > 0] */
-            size_t fmtLen = strlen(HTTP_CONTENT_LEN)+strlen(HTTP_CRLF_VALUE)+MAX_CONTENT_LENGTH+2;
+            size_t fmtLen = strlen(HTTP_CONTENT_LEN)+HTTP_CRLF_LEN+8;
             char* content = malloc(fmtLen+1);
             if (content == NULL)
             {
@@ -1030,10 +1029,10 @@ HTTP_CLIENT_HANDLE uhttp_client_create(const IO_INTERFACE_DESCRIPTION* io_interf
 void uhttp_client_destroy(HTTP_CLIENT_HANDLE handle)
 {
     /* Codes_SRS_UHTTP_07_004: [ If handle is NULL then uhttp_client_destroy shall do nothing ] */
-    if (handle != NULL)
+    if (handle)
     {
         /* Codes_SRS_UHTTP_07_005: [uhttp_client_destroy shall free any resource that is allocated in this translation unit] */
-        if(handle->host_name != NULL)
+        if(handle->host_name)
         {
             free(handle->host_name);
         }

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -105,7 +105,7 @@ static int initialize_received_data(HTTP_CLIENT_HANDLE_DATA* http_data)
 {
     int result = 0;
 
-    // Initialize data if neccessary
+    // Initialize data if necessary
     if (http_data->recv_msg.resp_header == NULL)
     {
         http_data->recv_msg.resp_header = HTTPHeaders_Alloc();
@@ -1033,6 +1033,10 @@ void uhttp_client_destroy(HTTP_CLIENT_HANDLE handle)
     if (handle != NULL)
     {
         /* Codes_SRS_UHTTP_07_005: [uhttp_client_destroy shall free any resource that is allocated in this translation unit] */
+        if(handle->host_name != NULL)
+        {
+            free(handle->host_name);
+        }
         singlylinkedlist_destroy(handle->data_list);
         xio_destroy(handle->xio_handle);
         free(handle->certificate);

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -148,7 +148,7 @@ static int process_status_code_line(const unsigned char* buffer, size_t len, siz
             }
             else
             {
-                initSpace = (const char*)buffer+index+1;
+                initSpace = (const char*)buffer + index + 1;
             }
             spaceFound++;
         }
@@ -157,7 +157,7 @@ static int process_status_code_line(const unsigned char* buffer, size_t len, siz
             *statusLen = (int)atol(status_code);
             if (index < len)
             {
-                *position = index+1;
+                *position = index + 1;
             }
             else
             {
@@ -835,8 +835,8 @@ static int construct_http_headers(HTTP_HEADERS_HANDLE http_header, size_t conten
         if (!hostname_found)
         {
             // calculate the size of the host header
-            size_t host_len = strlen(HTTP_HOST)+strlen(hostname)+MAX_CONTENT_LENGTH+2;
-            char* host_header = malloc(host_len+1);
+            size_t host_len = strlen(HTTP_HOST) + strlen(hostname) + MAX_CONTENT_LENGTH + 2;
+            char* host_header = malloc(host_len + 1);
             if (host_header == NULL)
             {
                 LogError("Failed allocating host header");
@@ -844,7 +844,7 @@ static int construct_http_headers(HTTP_HEADERS_HANDLE http_header, size_t conten
             }
             else
             {
-                if (snprintf(host_header, host_len+1, "%s: %s:%d\r\n", HTTP_HOST, hostname, port_num) <= 0)
+                if (snprintf(host_header, host_len + 1, "%s: %s:%d\r\n", HTTP_HOST, hostname, port_num) <= 0)
                 {
                     LogError("Failed constructing host header");
                     result = MU_FAILURE;
@@ -861,7 +861,7 @@ static int construct_http_headers(HTTP_HEADERS_HANDLE http_header, size_t conten
         if (result == 0)
         {
             /* Codes_SRS_UHTTP_07_015: [uhttp_client_execute_request shall add the Content-Length to the request if the contentLength is > 0] */
-            size_t fmtLen = strlen(HTTP_CONTENT_LEN)+HTTP_CRLF_LEN+8;
+            size_t fmtLen = strlen(HTTP_CONTENT_LEN) + HTTP_CRLF_LEN + 8;
             char* content = malloc(fmtLen+1);
             if (content == NULL)
             {
@@ -916,7 +916,7 @@ static STRING_HANDLE construct_http_data(HTTP_CLIENT_REQUEST_TYPE request_type, 
     }
     else
     {
-        size_t buffLen = strlen(HTTP_REQUEST_LINE_FMT)+strlen(method)+strlen(relative_path);
+        size_t buffLen = strlen(HTTP_REQUEST_LINE_FMT) + strlen(method) + strlen(relative_path);
         char* request = malloc(buffLen+1);
         if (request == NULL)
         {
@@ -925,7 +925,7 @@ static STRING_HANDLE construct_http_data(HTTP_CLIENT_REQUEST_TYPE request_type, 
         }
         else
         {
-            if (snprintf(request, buffLen+1, HTTP_REQUEST_LINE_FMT, method, relative_path) <= 0)
+            if (snprintf(request, buffLen + 1, HTTP_REQUEST_LINE_FMT, method, relative_path) <= 0)
             {
                 result = NULL;
                 LogError("Failure writing request buffer");
@@ -1059,7 +1059,9 @@ HTTP_CLIENT_RESULT uhttp_client_open(HTTP_CLIENT_HANDLE handle, const char* host
     {
         HTTP_CLIENT_HANDLE_DATA* http_data = (HTTP_CLIENT_HANDLE_DATA*)handle;
 
-        if (http_data->recv_msg.recv_state != state_initial && http_data->recv_msg.recv_state != state_error && http_data->recv_msg.recv_state != state_closed)
+        if ((http_data->recv_msg.recv_state != state_initial) &&
+            (http_data->recv_msg.recv_state != state_error) &&
+            (http_data->recv_msg.recv_state != state_closed))
         {
             LogError("Unable to open previously open client.");
             result = HTTP_CLIENT_INVALID_STATE;
@@ -1086,9 +1088,10 @@ HTTP_CLIENT_RESULT uhttp_client_open(HTTP_CLIENT_HANDLE handle, const char* host
                 http_data->connect_user_ctx = callback_ctx;
                 http_data->port_num = port_num;
 
-                if (http_data->x509_cert != NULL && http_data->x509_pk != NULL)
+                if ((http_data->x509_cert != NULL) && (http_data->x509_pk != NULL))
                 {
-                    if (xio_setoption(http_data->xio_handle, SU_OPTION_X509_CERT, http_data->x509_cert) != 0 || xio_setoption(http_data->xio_handle, SU_OPTION_X509_PRIVATE_KEY, http_data->x509_pk) != 0)
+                    if ((xio_setoption(http_data->xio_handle, SU_OPTION_X509_CERT, http_data->x509_cert) != 0) ||
+                        (xio_setoption(http_data->xio_handle, SU_OPTION_X509_PRIVATE_KEY, http_data->x509_pk) != 0))
                     {
                         LogError("Failed setting x509 certificate");
                         result = HTTP_CLIENT_ERROR;
@@ -1100,7 +1103,7 @@ HTTP_CLIENT_RESULT uhttp_client_open(HTTP_CLIENT_HANDLE handle, const char* host
                     }
                 }
 
-                if (result == HTTP_CLIENT_OK && http_data->certificate != NULL)
+                if ((result == HTTP_CLIENT_OK) && (http_data->certificate != NULL))
                 {
                     if (xio_setoption(http_data->xio_handle, OPTION_TRUSTED_CERT, http_data->certificate) != 0)
                     {

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -24,6 +24,7 @@
 #define TIME_MAX_BUFFER     16
 #define HTTP_CRLF_LEN       2
 #define HTTP_END_TOKEN_LEN  4
+#define MAX_CONTENT_LENGTH  16
 
 static const char* HTTP_REQUEST_LINE_FMT = "%s %s HTTP/1.1\r\n";
 static const char* HTTP_HOST = "Host";
@@ -834,7 +835,8 @@ static int construct_http_headers(HTTP_HEADERS_HANDLE http_header, size_t conten
         }
         if (!hostname_found)
         {
-            size_t host_len = strlen(HTTP_HOST)+strlen(hostname)+8+2;
+            // calculate the size of the host header
+            size_t host_len = strlen(HTTP_HOST)+strlen(hostname)+MAX_CONTENT_LENGTH+2;
             char* host_header = malloc(host_len+1);
             if (host_header == NULL)
             {
@@ -860,7 +862,7 @@ static int construct_http_headers(HTTP_HEADERS_HANDLE http_header, size_t conten
         if (result == 0)
         {
             /* Codes_SRS_UHTTP_07_015: [uhttp_client_execute_request shall add the Content-Length to the request if the contentLength is > 0] */
-            size_t fmtLen = strlen(HTTP_CONTENT_LEN)+strlen(HTTP_CRLF_VALUE)+8;
+            size_t fmtLen = strlen(HTTP_CONTENT_LEN)+strlen(HTTP_CRLF_VALUE)+MAX_CONTENT_LENGTH+2;
             char* content = malloc(fmtLen+1);
             if (content == NULL)
             {

--- a/tests/uhttp_ut/uhttp_ut.c
+++ b/tests/uhttp_ut/uhttp_ut.c
@@ -403,7 +403,7 @@ static int my_singlylinkedlist_remove(SINGLYLINKEDLIST_HANDLE list, LIST_ITEM_HA
 
     if (g_list_add_called)
     {
-        int i;
+        size_t i;
         for(i = 0; i < g_list_item_count; i++)
         {
             if (g_list_items[i] == item)
@@ -413,7 +413,7 @@ static int my_singlylinkedlist_remove(SINGLYLINKEDLIST_HANDLE list, LIST_ITEM_HA
                 break;
             }
         }
-        for (int j = i; j < g_list_item_count; j++)
+        for (size_t j = i; j < g_list_item_count; j++)
         {
             g_list_items[j] = g_list_items[j+1];
         }

--- a/tests/uhttp_ut/uhttp_ut.c
+++ b/tests/uhttp_ut/uhttp_ut.c
@@ -347,6 +347,8 @@ static void my_singlylinkedlist_destroy(SINGLYLINKEDLIST_HANDLE list)
 {
     my_gballoc_free(list);
     my_gballoc_free((void*)g_list_items);
+    g_list_items = NULL;
+    g_list_item_count = 0;
 }
 
 static LIST_ITEM_HANDLE my_singlylinkedlist_get_head_item(SINGLYLINKEDLIST_HANDLE list)
@@ -356,22 +358,27 @@ static LIST_ITEM_HANDLE my_singlylinkedlist_get_head_item(SINGLYLINKEDLIST_HANDL
     if (g_list_item_count > 0)
     {
         listHandle = (LIST_ITEM_HANDLE)g_list_items[0];
-        g_list_item_count--;
     }
     return listHandle;
 }
 
 static LIST_ITEM_HANDLE my_singlylinkedlist_add(SINGLYLINKEDLIST_HANDLE list, const void* item)
 {
-    const void** items = (const void**)my_gballoc_realloc((void*)g_list_items, (g_list_item_count + 1) * sizeof(item));
+    LIST_ITEM_HANDLE result;
     (void)list;
-    if (items != NULL)
+
+    const void** items = (const void**)my_gballoc_realloc((void*)g_list_items, (g_list_item_count + 1) * sizeof(item));
+    if (items == NULL)
+    {
+        result = NULL;
+    }
+    else
     {
         g_list_items = items;
         g_list_items[g_list_item_count++] = item;
     }
     g_list_add_called = true;
-    return (LIST_ITEM_HANDLE)g_list_item_count;
+    return (LIST_ITEM_HANDLE)item;
 }
 
 static const void* my_singlylinkedlist_item_get_value(LIST_ITEM_HANDLE item_handle)
@@ -392,12 +399,23 @@ static int my_singlylinkedlist_remove(SINGLYLINKEDLIST_HANDLE list, LIST_ITEM_HA
 {
     (void)list;
     (void)item;
+    int found = 0;
 
     if (g_list_add_called)
     {
-        if (g_list_item_count > 0)
+        int i;
+        for(i = 0; i < g_list_item_count; i++)
         {
-            g_list_item_count--;
+            if (g_list_items[i] == item)
+            {
+                found = 1;
+                g_list_item_count--;
+                break;
+            }
+        }
+        for (int j = i; j < g_list_item_count; j++)
+        {
+            g_list_items[j] = g_list_items[j+1];
         }
     }
     if (g_list_item_count == 0)
@@ -1230,34 +1248,6 @@ TEST_FUNCTION(uhttp_client_execute_request_with_content_succeed)
     uhttp_client_destroy(clientHandle);
 }
 
-TEST_FUNCTION(uhttp_client_reopen_with_new_hostname_succeed)
-{
-    // arrange
-    HTTP_CLIENT_HANDLE clientHandle = uhttp_client_create(TEST_INTERFACE_DESC, TEST_CREATE_PARAM, on_error_callback, NULL);
-    (void)uhttp_client_open(clientHandle, TEST_HOST_NAME, TEST_PORT_NUM, on_connection_callback, TEST_CONNECT_CONTEXT);
-    HTTP_CLIENT_RESULT httpResult = uhttp_client_execute_request(clientHandle, HTTP_CLIENT_REQUEST_POST, "/", TEST_HTTP_HEADERS_HANDLE, (const unsigned char*)TEST_HTTP_CONTENT, TEST_HTTP_CONTENT_LENGTH, on_msg_recv_callback, TEST_EXECUTE_CONTEXT);
-    umock_c_reset_all_calls();
-
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_NUM_ARG));
-    STRICT_EXPECTED_CALL(mallocAndStrcpy_s(IGNORED_PTR_ARG, TEST_HOST_NAME_2));
-    EXPECTED_CALL(xio_open(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
-    STRICT_EXPECTED_CALL(HTTPHeaders_Free(IGNORED_PTR_ARG));
-    STRICT_EXPECTED_CALL(BUFFER_delete(IGNORED_PTR_ARG));
-    setup_uhttp_client_execute_request_with_content_mocks();
-
-    // act
-    (void)uhttp_client_open(clientHandle, TEST_HOST_NAME_2, TEST_PORT_NUM, on_connection_callback, TEST_CONNECT_CONTEXT);
-    httpResult = uhttp_client_execute_request(clientHandle, HTTP_CLIENT_REQUEST_POST, "/", TEST_HTTP_HEADERS_HANDLE, (const unsigned char*)TEST_HTTP_CONTENT, TEST_HTTP_CONTENT_LENGTH, on_msg_recv_callback, TEST_EXECUTE_CONTEXT);
-
-    // assert
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_EQUAL(HTTP_CLIENT_RESULT, HTTP_CLIENT_OK, httpResult);
-
-    // Cleanup
-    uhttp_client_close(clientHandle, on_closed_callback, NULL);
-    uhttp_client_destroy(clientHandle);
-}
-
 /* Tests_SRS_UHTTP_07_046: [ http_client_dowork shall free resouces queued to send to the http endpoint. ] */
 TEST_FUNCTION(uhttp_client_execute_request_with_content_fails)
 {
@@ -1291,6 +1281,32 @@ TEST_FUNCTION(uhttp_client_execute_request_with_content_fails)
 
     // Cleanup
     umock_c_negative_tests_deinit();
+    uhttp_client_close(clientHandle, on_closed_callback, NULL);
+    uhttp_client_destroy(clientHandle);
+}
+
+TEST_FUNCTION(uhttp_client_execute_request_multiple_succeed)
+{
+    // arrange
+    HTTP_CLIENT_HANDLE clientHandle = uhttp_client_create(TEST_INTERFACE_DESC, TEST_CREATE_PARAM, on_error_callback, NULL);
+    (void)uhttp_client_open(clientHandle, TEST_HOST_NAME, TEST_PORT_NUM, on_connection_callback, TEST_CONNECT_CONTEXT);
+    HTTP_CLIENT_RESULT httpResult1 = uhttp_client_execute_request(clientHandle, HTTP_CLIENT_REQUEST_POST, "/", TEST_HTTP_HEADERS_HANDLE, (const unsigned char*)TEST_HTTP_CONTENT, TEST_HTTP_CONTENT_LENGTH, on_msg_recv_callback, TEST_EXECUTE_CONTEXT);
+    HTTP_CLIENT_RESULT httpResult2 = uhttp_client_execute_request(clientHandle, HTTP_CLIENT_REQUEST_POST, "/", TEST_HTTP_HEADERS_HANDLE, (const unsigned char*)TEST_HTTP_CONTENT, TEST_HTTP_CONTENT_LENGTH, on_msg_recv_callback, TEST_EXECUTE_CONTEXT);
+    umock_c_reset_all_calls();
+
+    STRICT_EXPECTED_CALL(HTTPHeaders_Free(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(BUFFER_delete(IGNORED_PTR_ARG));
+    setup_uhttp_client_execute_request_with_content_mocks();
+
+    HTTP_CLIENT_RESULT httpResult3 = uhttp_client_execute_request(clientHandle, HTTP_CLIENT_REQUEST_POST, "/", TEST_HTTP_HEADERS_HANDLE, (const unsigned char*)TEST_HTTP_CONTENT, TEST_HTTP_CONTENT_LENGTH, on_msg_recv_callback, TEST_EXECUTE_CONTEXT);
+
+    // assert
+    ASSERT_ARE_EQUAL(HTTP_CLIENT_RESULT, HTTP_CLIENT_OK, httpResult1);
+    ASSERT_ARE_EQUAL(HTTP_CLIENT_RESULT, HTTP_CLIENT_OK, httpResult2);
+    ASSERT_ARE_EQUAL(HTTP_CLIENT_RESULT, HTTP_CLIENT_OK, httpResult3);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // Cleanup
     uhttp_client_close(clientHandle, on_closed_callback, NULL);
     uhttp_client_destroy(clientHandle);
 }


### PR DESCRIPTION
- Content header creation (cherry picked from  https://github.com/Azure/azure-uhttp-c/pull/44)
- Fixing memory leak in uhttp when the application doesn't close the client (application is still required to call do_work or close to prevent a leak)
- Fixing unit test mock list.
- Merging #47 and #44 