### PR TITLE
Remove auth data from log text string

### DIFF
--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -34,7 +34,7 @@ static const char* HTTP_TRANSFER_ENCODING = "transfer-encoding";
 static const char* HTTP_CRLF_VALUE = "\r\n";
 static const char* HEADER_ENDING = "\x0A";
 static const char* AUTH_HEADER = "Authorization:";
-static const char* AUTH_HEADER_TWO = "\nAuthorization";
+static const char* AUTH_HEADER_TWO = "\nAuthorization:";
 static const char* PROXY_AUTH_HEADER = "Proxy-Authorization:";
 
 typedef enum RESPONSE_MESSAGE_STATE_TAG

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -371,7 +371,7 @@ static int write_text_line(HTTP_CLIENT_HANDLE_DATA* http_data, const char* text_
         result = 0;
         if (http_data->trace_on)
         {
-            log_data_line(http_data, text_line);;
+            log_data_line(http_data, text_line);
         }
     }
     return result;

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -32,9 +32,8 @@ static const char* HTTP_HOST = "Host";
 static const char* HTTP_CONTENT_LEN = "content-length";
 static const char* HTTP_TRANSFER_ENCODING = "transfer-encoding";
 static const char* HTTP_CRLF_VALUE = "\r\n";
-static const char* HEADER_ENDING = "\x0A";
-static const char* AUTH_HEADER = "Authorization:";
-static const char* PROXY_AUTH_HEADER = "Proxy-Authorization:";
+static const char* AUTH_HEADER = "\r\nAuthorization:";
+static const char* PROXY_AUTH_HEADER = "\r\nProxy-Authorization:";
 
 typedef enum RESPONSE_MESSAGE_STATE_TAG
 {
@@ -319,13 +318,11 @@ static void log_data_line(HTTP_CLIENT_HANDLE_DATA* http_data, const char* text_l
 
     if (authStart != NULL)
     {
-        authEol = strstr(authStart, HEADER_ENDING);
+        authEol = strstr((authStart + 1), HTTP_CRLF_VALUE);
     }
     if (proxyAuthStart != NULL)
     {
-        proxyAuthEol = strstr(proxyAuthStart, HEADER_ENDING);
-        authStart = strstr(proxyAuthEol, AUTH_HEADER);
-        authEol = strstr(authStart, HEADER_ENDING);
+        proxyAuthEol = strstr((proxyAuthStart + 1), HTTP_CRLF_VALUE);
     }
     if (authStart == NULL && proxyAuthStart == NULL)
     {
@@ -335,14 +332,14 @@ static void log_data_line(HTTP_CLIENT_HANDLE_DATA* http_data, const char* text_l
     {
         if (authEol != NULL)
         {                                                                 
-            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s Authorization: *** %.*s", (int)(authStart  - text_line), text_line, (int)(strlen(text_line) - (authEol - text_line)), authEol);
+            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s \r\nAuthorization: *** %.*s", (int)(authStart  - text_line), text_line, (int)(strlen(text_line) - (authEol - text_line)), authEol);
         }
     }
     else if (proxyAuthStart != NULL && authStart == NULL)
     {
         if (proxyAuthEol != NULL)
         {
-            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s Proxy-Authorization: *** %.*s", (int)(proxyAuthStart  - text_line), text_line, (int)(strlen(text_line) - (proxyAuthEol - text_line)), proxyAuthEol);
+            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s \r\nProxy-Authorization: *** %.*s", (int)(proxyAuthStart  - text_line), text_line, (int)(strlen(text_line) - (proxyAuthEol - text_line)), proxyAuthEol);
         }
     }
     else
@@ -351,11 +348,11 @@ static void log_data_line(HTTP_CLIENT_HANDLE_DATA* http_data, const char* text_l
         int proxyAuthPos = proxyAuthStart - text_line;
         if(authPos < proxyAuthPos)
         {
-            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s Authorization: *** %.*s Proxy-Authorization: *** %.*s", (int)(authStart - text_line), text_line, (int)(proxyAuthStart - authEol), authEol, (int)(proxyAuthEol - text_line), proxyAuthEol);
+            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s \r\nAuthorization: *** %.*s \r\nProxy-Authorization: *** %.*s", (int)(authStart - text_line), text_line, (int)(proxyAuthStart - authEol), authEol, (int)(proxyAuthEol - text_line), proxyAuthEol);
         }
         else
         {
-            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s Proxy-Authorization: *** %.*s Authorization: *** %.*s", (int)(proxyAuthStart - text_line), text_line, (int)(authStart - proxyAuthEol), proxyAuthEol, (int)(authEol - text_line), authEol);
+            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s \r\nProxy-Authorization: *** %.*s \r\nAuthorization: *** %.*s", (int)(proxyAuthStart - text_line), text_line, (int)(authStart - proxyAuthEol), proxyAuthEol, (int)(authEol - text_line), authEol);
         }
     }
 }

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -334,7 +334,9 @@ static void log_text_line(const char* text_line)
     {
         if (authEol != NULL)
         {                                                                 
-            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s \r\nAuthorization: *** %.*s", (int)(authStart  - text_line), text_line, (int)(strlen(text_line) - (authEol - text_line)), authEol);
+            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s \r\nAuthorization: *** %.*s",
+                                                                 (int)(authStart  - text_line), text_line,
+                                                                 (int)(strlen(text_line) - (authEol - text_line)), authEol);
         }
     }
     else if (authStart == NULL)

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -335,14 +335,14 @@ static void log_data_line(HTTP_CLIENT_HANDLE_DATA* http_data, const char* text_l
     {
         if (authEol != NULL)
         {                                                                 
-            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s Authorization: ************** %.*s", (int)(authStart  - text_line), text_line, (int)(strlen(text_line) - (authEol - text_line)), authEol);
+            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s Authorization: *** %.*s", (int)(authStart  - text_line), text_line, (int)(strlen(text_line) - (authEol - text_line)), authEol);
         }
     }
     else if (proxyAuthStart != NULL && authStart == NULL)
     {
         if (proxyAuthEol != NULL)
         {
-            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s Proxy-Authorization: ************** %.*s", (int)(proxyAuthStart  - text_line), text_line, (int)(strlen(text_line) - (proxyAuthEol - text_line)), proxyAuthEol);
+            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s Proxy-Authorization: *** %.*s", (int)(proxyAuthStart  - text_line), text_line, (int)(strlen(text_line) - (proxyAuthEol - text_line)), proxyAuthEol);
         }
     }
     else
@@ -351,14 +351,11 @@ static void log_data_line(HTTP_CLIENT_HANDLE_DATA* http_data, const char* text_l
         int proxyAuthPos = proxyAuthStart - text_line;
         if(authPos < proxyAuthPos)
         {
-            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s Authorization: ************** %.*s Proxy-Authorization: ************** %.*s", (int)(authStart - text_line), text_line, (int)(proxyAuthStart - authEol), authEol,
-(int)(proxyAuthEol - text_line),
-proxyAuthEol);
+            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s Authorization: *** %.*s Proxy-Authorization: *** %.*s", (int)(authStart - text_line), text_line, (int)(proxyAuthStart - authEol), authEol, (int)(proxyAuthEol - text_line), proxyAuthEol);
         }
         else
         {
-            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s Proxy-Authorization: ************** %.*s Authorization: ************** %.*s", (int)(proxyAuthStart - text_line), text_line, (int)(authStart - proxyAuthEol), proxyAuthEol,(int)(authEol -
-text_line),authEol);
+            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s Proxy-Authorization: *** %.*s Authorization: *** %.*s", (int)(proxyAuthStart - text_line), text_line, (int)(authStart - proxyAuthEol), proxyAuthEol, (int)(authEol - text_line), authEol);
         }
     }
 }

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -369,7 +369,7 @@ static int write_text_line(HTTP_CLIENT_HANDLE_DATA* http_data, const char* text_
         result = 0;
         if (http_data->trace_on)
         {
-            log_text_line(http_data, text_line);
+            log_text_line(text_line);
         }
     }
     return result;

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -322,7 +322,7 @@ static int write_text_line(HTTP_CLIENT_HANDLE_DATA* http_data, static const char
         if (http_data->trace_on)
         {
             char* authStart = strstr(text_line, "Authorization:");
-            char* proxyAuthStart = strstr(text_line, "Proxy-Authorization");
+            char* proxyAuthStart = strstr(text_line, "Proxy-Authorization:");
             if (authStart == NULL && proxyAuthStart == NULL)
             {
                 LOG(AZ_LOG_TRACE, LOG_LINE, "%s", text_line);

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -307,7 +307,7 @@ static int process_header_line(const unsigned char* buffer, size_t len, size_t* 
     return result;
 }
 
-static int write_text_line(HTTP_CLIENT_HANDLE_DATA* http_data, const char* text_line)
+static int write_text_line(HTTP_CLIENT_HANDLE_DATA* http_data, static const char* text_line)
 {
     int result;
 
@@ -316,45 +316,36 @@ static int write_text_line(HTTP_CLIENT_HANDLE_DATA* http_data, const char* text_
         LogError("Failure calling xio_send.");
         result = MU_FAILURE;
     }
-
     else
     {
         result = 0;
-
         if (http_data->trace_on)
         {
             char* authStart = strstr(text_line, "Authorization:");
             char* proxyAuthStart = strstr(text_line, "Proxy-Authorization");
-
             if (authStart == NULL && proxyAuthStart == NULL)
             {
                 LOG(AZ_LOG_TRACE, LOG_LINE, "%s", text_line);
             }
-
             else if (authStart != NULL && proxyAuthStart == NULL)
             {
                 char* authEol = strstr(authStart, "\x0D\x0A");
-
                 if (authEol != NULL)
                 {                                                                 
                     LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s ************** %.*s", (int)(authStart  - text_line), text_line, (int)(strlen(text_line) - (authEol - text_line)), authEol);
                 }
             }
-
             else if (proxyAuthStart != NULL && authStart == NULL)
             {
                 char* proxyAuthEol = strstr(proxyAuthStart, "\x0D\x0A");
-
                 if (proxyAuthEol != NULL)
                 {
                     LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s ************** %.*s", (int)(proxyAuthStart  - text_line), text_line, (int)(strlen(text_line) - (proxyAuthEol - text_line)), proxyAuthEol);
                 }
             }
-
             else if (proxyAuthStart != NULL && authStart != NULL)
             {
                 char* proxyAuthEol = strstr(proxyAuthStart, "\x0D\x0A");
-
                 if (proxyAuthEol != NULL)
                 {
                     LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s **************\n************** %.*s", (int)(authStart  - text_line), text_line, (int)(strlen(text_line) - (proxyAuthEol - text_line)), proxyAuthEol);
@@ -362,7 +353,6 @@ static int write_text_line(HTTP_CLIENT_HANDLE_DATA* http_data, const char* text_
             }
         }
     }
-
     return result;
 }
 

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -344,8 +344,8 @@ static void log_data_line(HTTP_CLIENT_HANDLE_DATA* http_data, const char* text_l
     }
     else
     {
-        int authPos = authStart - text_line;
-        int proxyAuthPos = proxyAuthStart - text_line;
+        long int authPos = authStart - text_line;
+        long int proxyAuthPos = proxyAuthStart - text_line;
         if(authPos < proxyAuthPos)
         {
             LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s \r\nAuthorization: *** %.*s \r\nProxy-Authorization: *** %.*s", (int)(authStart - text_line), text_line, (int)(proxyAuthStart - authEol), authEol, (int)(proxyAuthEol - text_line), proxyAuthEol);

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -320,10 +320,12 @@ static void log_text_line(const char* text_line)
     {
         authEol = strstr((authStart + 1), HTTP_CRLF_VALUE);
     }
+
     if (proxyAuthStart != NULL)
     {
         proxyAuthEol = strstr((proxyAuthStart + 1), HTTP_CRLF_VALUE);
     }
+
     if (authStart == NULL && proxyAuthStart == NULL)
     {
         LOG(AZ_LOG_TRACE, LOG_LINE, "%s", text_line);

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -328,14 +328,14 @@ static void log_text_line(const char* text_line)
     {
         LOG(AZ_LOG_TRACE, LOG_LINE, "%s", text_line);
     }
-    else if (authStart != NULL && proxyAuthStart == NULL)
+    else if (proxyAuthStart == NULL)
     {
         if (authEol != NULL)
         {                                                                 
             LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s \r\nAuthorization: *** %.*s", (int)(authStart  - text_line), text_line, (int)(strlen(text_line) - (authEol - text_line)), authEol);
         }
     }
-    else if (proxyAuthStart != NULL && authStart == NULL)
+    else if (authStart == NULL)
     {
         if (proxyAuthEol != NULL)
         {

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -309,7 +309,7 @@ static int process_header_line(const unsigned char* buffer, size_t len, size_t* 
     return result;
 }
 
-static void log_data_line(HTTP_CLIENT_HANDLE_DATA* http_data, const char* text_line)
+static void log_text_line(HTTP_CLIENT_HANDLE_DATA* http_data, const char* text_line)
 {
     char* authStart = strstr(text_line, AUTH_HEADER);
     char* proxyAuthStart = strstr(text_line, PROXY_AUTH_HEADER);
@@ -369,7 +369,7 @@ static int write_text_line(HTTP_CLIENT_HANDLE_DATA* http_data, const char* text_
         result = 0;
         if (http_data->trace_on)
         {
-            log_data_line(http_data, text_line);
+            log_text_line(http_data, text_line);
         }
     }
     return result;

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -309,7 +309,7 @@ static int process_header_line(const unsigned char* buffer, size_t len, size_t* 
     return result;
 }
 
-static void log_text_line(HTTP_CLIENT_HANDLE_DATA* http_data, const char* text_line)
+static void log_text_line(const char* text_line)
 {
     char* authStart = strstr(text_line, AUTH_HEADER);
     char* proxyAuthStart = strstr(text_line, PROXY_AUTH_HEADER);

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -352,7 +352,10 @@ static void log_text_line(const char* text_line)
     {
         if(authStart < proxyAuthStart)
         {
-            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s \r\nAuthorization: *** %.*s \r\nProxy-Authorization: *** %.*s", (int)(authStart - text_line), text_line, (int)(proxyAuthStart - authEol), authEol, (int)(proxyAuthEol - text_line), proxyAuthEol);
+            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s \r\nAuthorization: *** %.*s \r\nProxy-Authorization: *** %.*s",
+                               (int)(authStart - text_line), text_line,
+                               (int)(proxyAuthStart - authEol), authEol,
+                               (int)(proxyAuthEol - text_line), proxyAuthEol);
         }
         else
         {

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -344,9 +344,7 @@ static void log_data_line(HTTP_CLIENT_HANDLE_DATA* http_data, const char* text_l
     }
     else
     {
-        long int authPos = authStart - text_line;
-        long int proxyAuthPos = proxyAuthStart - text_line;
-        if(authPos < proxyAuthPos)
+        if(authStart < proxyAuthStart)
         {
             LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s \r\nAuthorization: *** %.*s \r\nProxy-Authorization: *** %.*s", (int)(authStart - text_line), text_line, (int)(proxyAuthStart - authEol), authEol, (int)(proxyAuthEol - text_line), proxyAuthEol);
         }

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -359,7 +359,10 @@ static void log_text_line(const char* text_line)
         }
         else
         {
-            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s \r\nProxy-Authorization: *** %.*s \r\nAuthorization: *** %.*s", (int)(proxyAuthStart - text_line), text_line, (int)(authStart - proxyAuthEol), proxyAuthEol, (int)(authEol - text_line), authEol);
+            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s \r\nProxy-Authorization: *** %.*s \r\nAuthorization: *** %.*s",
+            (int)(proxyAuthStart - text_line), text_line,
+            (int)(authStart - proxyAuthEol), proxyAuthEol,
+            (int)(authEol - text_line), authEol);
         }
     }
 }

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -32,8 +32,8 @@ static const char* HTTP_HOST = "Host";
 static const char* HTTP_CONTENT_LEN = "content-length";
 static const char* HTTP_TRANSFER_ENCODING = "transfer-encoding";
 static const char* HTTP_CRLF_VALUE = "\r\n";
-static const char* AUTH_HEADER = "\r\nAuthorization:";
-static const char* PROXY_AUTH_HEADER = "\r\nProxy-Authorization:";
+static const char* HTTP_AUTH_HEADER = "\r\nAuthorization:";
+static const char* HTTP_PROXY_AUTH_HEADER = "\r\nProxy-Authorization:";
 
 typedef enum RESPONSE_MESSAGE_STATE_TAG
 {
@@ -311,8 +311,8 @@ static int process_header_line(const unsigned char* buffer, size_t len, size_t* 
 
 static void log_text_line(const char* text_line)
 {
-    char* authStart = strstr(text_line, AUTH_HEADER);
-    char* proxyAuthStart = strstr(text_line, PROXY_AUTH_HEADER);
+    char* authStart = strstr(text_line, HTTP_AUTH_HEADER);
+    char* proxyAuthStart = strstr(text_line, HTTP_PROXY_AUTH_HEADER);
     char* authEol = NULL;
     char* proxyAuthEol = NULL;
 

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -32,6 +32,9 @@ static const char* HTTP_HOST = "Host";
 static const char* HTTP_CONTENT_LEN = "content-length";
 static const char* HTTP_TRANSFER_ENCODING = "transfer-encoding";
 static const char* HTTP_CRLF_VALUE = "\r\n";
+static const char* HEADER_ENDING = "\x0A";
+static const char* AUTH_HEADER = "Authorization:";
+static const char* PROXY_AUTH_HEADER = "Proxy-Authorization:";
 
 typedef enum RESPONSE_MESSAGE_STATE_TAG
 {
@@ -307,7 +310,7 @@ static int process_header_line(const unsigned char* buffer, size_t len, size_t* 
     return result;
 }
 
-static int write_text_line(HTTP_CLIENT_HANDLE_DATA* http_data, static const char* text_line)
+static int write_text_line(HTTP_CLIENT_HANDLE_DATA* http_data, const char* text_line)
 {
     int result;
 
@@ -321,15 +324,15 @@ static int write_text_line(HTTP_CLIENT_HANDLE_DATA* http_data, static const char
         result = 0;
         if (http_data->trace_on)
         {
-            char* authStart = strstr(text_line, "Authorization:");
-            char* proxyAuthStart = strstr(text_line, "Proxy-Authorization:");
+            char* authStart = strstr(text_line, AUTH_HEADER);
+            char* proxyAuthStart = strstr(text_line, PROXY_AUTH_HEADER);
             if (authStart == NULL && proxyAuthStart == NULL)
             {
                 LOG(AZ_LOG_TRACE, LOG_LINE, "%s", text_line);
             }
             else if (authStart != NULL && proxyAuthStart == NULL)
             {
-                char* authEol = strstr(authStart, "\x0D\x0A");
+                char* authEol = strstr(authStart, HEADER_ENDING);
                 if (authEol != NULL)
                 {                                                                 
                     LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s ************** %.*s", (int)(authStart  - text_line), text_line, (int)(strlen(text_line) - (authEol - text_line)), authEol);
@@ -337,7 +340,7 @@ static int write_text_line(HTTP_CLIENT_HANDLE_DATA* http_data, static const char
             }
             else if (proxyAuthStart != NULL && authStart == NULL)
             {
-                char* proxyAuthEol = strstr(proxyAuthStart, "\x0D\x0A");
+                char* proxyAuthEol = strstr(proxyAuthStart, HEADER_ENDING);
                 if (proxyAuthEol != NULL)
                 {
                     LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s ************** %.*s", (int)(proxyAuthStart  - text_line), text_line, (int)(strlen(text_line) - (proxyAuthEol - text_line)), proxyAuthEol);
@@ -345,7 +348,7 @@ static int write_text_line(HTTP_CLIENT_HANDLE_DATA* http_data, static const char
             }
             else if (proxyAuthStart != NULL && authStart != NULL)
             {
-                char* proxyAuthEol = strstr(proxyAuthStart, "\x0D\x0A");
+                char* proxyAuthEol = strstr(proxyAuthStart, HEADER_ENDING);
                 if (proxyAuthEol != NULL)
                 {
                     LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s **************\n************** %.*s", (int)(authStart  - text_line), text_line, (int)(strlen(text_line) - (proxyAuthEol - text_line)), proxyAuthEol);

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -377,7 +377,7 @@ static int write_text_line(HTTP_CLIENT_HANDLE_DATA* http_data, const char* text_
         result = 0;
         if (http_data->trace_on)
         {
-            log_data_line;
+            log_data_line(http_data, text_line);;
         }
     }
     return result;

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -343,7 +343,9 @@ static void log_text_line(const char* text_line)
     {
         if (proxyAuthEol != NULL)
         {
-            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s \r\nProxy-Authorization: *** %.*s", (int)(proxyAuthStart  - text_line), text_line, (int)(strlen(text_line) - (proxyAuthEol - text_line)), proxyAuthEol);
+            LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s \r\nProxy-Authorization: *** %.*s",
+                                                     (int)(proxyAuthStart  - text_line), text_line,
+                                                     (int)(strlen(text_line) - (proxyAuthEol - text_line)), proxyAuthEol);
         }
     }
     else

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -353,7 +353,7 @@ static int write_text_line(HTTP_CLIENT_HANDLE_DATA* http_data, const char* text_
                 int proxyAuthPos = proxyAuthStart - text_line;
                 if(authPos < proxyAuthPos)
                 {
-                    LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s ***** %.*s ***** %.*s", (int)(authStart - text_line), text_line, (int)(proxyAuthStart - authEol), authEol,
+                    LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s ************** %.*s ************** %.*s", (int)(authStart - text_line), text_line, (int)(proxyAuthStart - authEol), authEol,
 (int)(proxyAuthEol - text_line),
 proxyAuthEol);
                 }
@@ -363,7 +363,7 @@ proxyAuthEol);
                     secondAuthStart++;
                     char* authEolTwo = strstr(secondAuthStart, AUTH_HEADER_TWO);
 
-                    LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s ******* %.*s ******* %.*s", (int)(proxyAuthStart - text_line), text_line, (int)(secondAuthStart - proxyAuthEol), proxyAuthEol,(int)(authEolTwo -
+                    LOG(AZ_LOG_TRACE, LOG_LINE, "%.*s ************** %.*s ************** %.*s", (int)(proxyAuthStart - text_line), text_line, (int)(secondAuthStart - proxyAuthEol), proxyAuthEol,(int)(authEolTwo -
 text_line),authEolTwo);
                 }
             }


### PR DESCRIPTION
**Description of the problem:** 
text_line gets sent to the wire with sensitive information and is therefore logging info such as SAS tokens and proxy authentication info.

**Description of the the solution:**
Pass the text_line string with the following headers removed:

Authorization
Proxy-Authorization