### PR TITLE
Fix out-of-bounds read in HTTP status-line parser

### DIFF
--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -146,6 +146,12 @@ static int process_status_code_line(const unsigned char* buffer, size_t len, siz
         {
             if (spaceFound == 1)
             {
+                // Guard against reading past the end of the buffer. initSpace points
+                // just past the first space; ensure 3 bytes are available before copying.
+                if ((size_t)(initSpace - (const char*)buffer) + 3 > len)
+                {
+                    break;
+                }
                 (void)memcpy(status_code, initSpace, 3);
                 status_code[3] = '\0';
             }

--- a/src/uhttp.c
+++ b/src/uhttp.c
@@ -1286,6 +1286,11 @@ void uhttp_client_close(HTTP_CLIENT_HANDLE handle, ON_HTTP_CLOSED_CALLBACK on_cl
             BUFFER_delete(http_data->recv_msg.msg_body);
             http_data->recv_msg.msg_body = NULL;
         }
+        if (http_data->recv_msg.accrual_buff != NULL)
+        {
+            BUFFER_delete(http_data->recv_msg.accrual_buff);
+            http_data->recv_msg.accrual_buff = NULL;
+        }
     }
 }
 

--- a/tests/uhttp_ut/uhttp_ut.c
+++ b/tests/uhttp_ut/uhttp_ut.c
@@ -1513,6 +1513,36 @@ TEST_FUNCTION(uhttp_client_onBytesReceived_buffer_NULL_fail)
     uhttp_client_destroy(clientHandle);
 }
 
+/* Tests_SRS_UHTTP_07_048: [ If any error is encountered on_bytes_received shall set the state to error. ] */
+// A status-line fragment containing two adjacent/early spaces, where the buffer ends within
+// 2 bytes of the status-code token, must not cause an out-of-bounds read in
+// process_status_code_line (CWE-125). The fragment is incomplete (no '\n'), so no message
+// callback shall be raised and the parser shall wait for additional bytes.
+TEST_FUNCTION(uhttp_client_onBytesReceived_status_line_short_fragment_no_oob_read)
+{
+    // arrange
+    HTTP_CLIENT_HANDLE clientHandle = uhttp_client_create(TEST_INTERFACE_DESC, TEST_CREATE_PARAM, on_error_callback, (void*)TEST_HTTP_EXAMPLE);
+    (void)uhttp_client_open(clientHandle, TEST_HOST_NAME, TEST_PORT_NUM, on_connection_callback, TEST_CONNECT_CONTEXT);
+    (void)uhttp_client_execute_request(clientHandle, HTTP_CLIENT_REQUEST_GET, "/", TEST_HTTP_HEADERS_HANDLE, (const unsigned char*)TEST_HTTP_CONTENT, TEST_HTTP_CONTENT_LENGTH, on_msg_recv_callback, TEST_EXECUTE_CONTEXT);
+    umock_c_reset_all_calls();
+
+    ASSERT_IS_NOT_NULL(g_onBytesRecv);
+
+    // A 3-byte fragment ending in two spaces: initSpace ends up at the last byte, leaving
+    // fewer than 3 bytes for the status-code copy. Run under ASan to catch the over-read.
+    const unsigned char short_status_fragment[] = { 'A', ' ', ' ' };
+
+    // act
+    g_onBytesRecv(g_onBytesRecv_ctx, short_status_fragment, sizeof(short_status_fragment));
+
+    // assert
+    ASSERT_ARE_EQUAL(int, 0, (int)g_http_cb_status_code);
+
+    // Cleanup
+    uhttp_client_close(clientHandle, on_closed_callback, NULL);
+    uhttp_client_destroy(clientHandle);
+}
+
 /* Tests_SRS_UHTTP_07_015: [on_bytes_received shall add the Content-Length http header item to the request.] */
 /* Tests_SRS_UHTTP_07_047: [ If context or buffer is NULL on_bytes_received shall do nothing. ] */
 /* Tests_SRS_UHTTP_07_048: [ If any error is encountered on_bytes_received shall set the state to error. ] */


### PR DESCRIPTION
process_status_code_line copied 3 bytes for the status code without verifying that 3 bytes remained in the receive buffer. A status-line fragment ending within 2 bytes of the status-code token (e.g. an early double space) delivered in a partial segment could read past the end of the exactly-sized accrual buffer. Bound the read before the copy and bail on incomplete/malformed fragments so parsing resumes as more bytes arrive. Add a regression unit test feeding a short status-line fragment.